### PR TITLE
Add pagination to task list

### DIFF
--- a/task_manager/tasks/views.py
+++ b/task_manager/tasks/views.py
@@ -1,3 +1,5 @@
+from multiprocessing import context
+
 from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib import messages
 from task_manager.permissions import CustomPermissions, UNAUTHORIZED_MESSAGE
@@ -100,6 +102,7 @@ class TaskFilterView(CustomPermissions, FilterView):
     model = Task
     template_name = 'tasks/task_filter.html'
     filterset_class = TaskFilter
+    paginate_by = 50     
 
     def get(self, request, *args, **kwargs):
         # Handle reset filter button (removes saved default filter)
@@ -275,6 +278,10 @@ class TaskFilterView(CustomPermissions, FilterView):
         context['current_sort_label'] = SORT_OPTIONS.get(
             current_sort, SORT_OPTIONS[DEFAULT_SORT])
         context['sort_options'] = SORT_OPTIONS
+        
+        query_params = self.request.GET.copy()
+        query_params.pop('page', None)
+        context['query_string'] = query_params.urlencode()
 
         return context
 

--- a/task_manager/tasks/views.py
+++ b/task_manager/tasks/views.py
@@ -46,6 +46,7 @@ SERVICE_PARAMS = (
     'reset_default',
     'view_mode',
     'sort',
+    'page',
 )
 
 # Sort options for task list

--- a/task_manager/tasks/views.py
+++ b/task_manager/tasks/views.py
@@ -1,5 +1,3 @@
-from multiprocessing import context
-
 from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib import messages
 from task_manager.permissions import CustomPermissions, UNAUTHORIZED_MESSAGE

--- a/task_manager/tasks/views.py
+++ b/task_manager/tasks/views.py
@@ -100,7 +100,7 @@ class TaskFilterView(CustomPermissions, FilterView):
     model = Task
     template_name = 'tasks/task_filter.html'
     filterset_class = TaskFilter
-    paginate_by = 50     
+    paginate_by = 50
 
     def get(self, request, *args, **kwargs):
         # Handle reset filter button (removes saved default filter)
@@ -276,7 +276,7 @@ class TaskFilterView(CustomPermissions, FilterView):
         context['current_sort_label'] = SORT_OPTIONS.get(
             current_sort, SORT_OPTIONS[DEFAULT_SORT])
         context['sort_options'] = SORT_OPTIONS
-        
+
         query_params = self.request.GET.copy()
         query_params.pop('page', None)
         context['query_string'] = query_params.urlencode()

--- a/task_manager/templates/tasks/task_filter.html
+++ b/task_manager/templates/tasks/task_filter.html
@@ -421,14 +421,14 @@
             <a class="page-link"
                href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.previous_page_number }}">
                 <i class="bi bi-chevron-left"></i>
-                Previous
+                {% trans "Previous" %}
             </a>
         </li>
         {% else %}
         <li class="page-item disabled">
             <span class="page-link">
                 <i class="bi bi-chevron-left"></i>
-                Previous
+                {% trans "Previous" %}
             </span>
         </li>
         {% endif %}
@@ -448,14 +448,14 @@
         <li class="page-item">
             <a class="page-link"
                href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.next_page_number }}">
-                Next
+                {% trans "Next" %}
                 <i class="bi bi-chevron-right"></i>
             </a>
         </li>
         {% else %}
         <li class="page-item disabled">
             <span class="page-link">
-                Next
+                {% trans "Next" %}
                 <i class="bi bi-chevron-right"></i>
             </span>
         </li>

--- a/task_manager/templates/tasks/task_filter.html
+++ b/task_manager/templates/tasks/task_filter.html
@@ -305,7 +305,7 @@
         <!-- Simple view -->
         <div class="d-flex flex-column gap-1">
             {% if filter.qs %}
-                {% for obj in filter.qs %}
+                {% for obj in page_obj %}
                 <div class="simple-task-item py-2 px-2{% if forloop.last %} rounded-bottom{% else %} border-bottom{% endif %}{% if forloop.first %} rounded-top{% endif %}">
                     <a href="{% url 'tasks:task-update' obj.uuid %}" class="text-decoration-none text-body d-flex align-items-center gap-2">
                         <span class="status-dot flex-shrink-0" style="background-color: {{ obj.status.color|default:'#dee2e6' }};"></span>
@@ -342,7 +342,7 @@
         <!-- Full view (cards) -->
         <div class="d-flex flex-column gap-3">
             {% if filter.qs %}
-                {% for obj in filter.qs %}
+                {% for obj in page_obj %}
                 <div class="card border-0 shadow-sm task-card{% if obj.status %} status-indicator{% endif %}"{% if obj.status %} style="--status-color: {{ obj.status.color|default:'#dee2e6' }};"{% endif %}>
                     <div class="card-body p-3">
                         <div class="d-flex w-100 justify-content-between align-items-start mb-1">
@@ -411,6 +411,59 @@
         </div>
     {% endif %}
 
+{% if is_paginated %}
+<nav aria-label="Task pagination" class="mt-4">
+    <ul class="pagination justify-content-center">
+
+        <!-- Previous -->
+        {% if page_obj.has_previous %}
+        <li class="page-item">
+            <a class="page-link"
+               href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.previous_page_number }}">
+                <i class="bi bi-chevron-left"></i>
+                Previous
+            </a>
+        </li>
+        {% else %}
+        <li class="page-item disabled">
+            <span class="page-link">
+                <i class="bi bi-chevron-left"></i>
+                Previous
+            </span>
+        </li>
+        {% endif %}
+
+        <!-- Page Numbers -->
+        {% for num in paginator.page_range %}
+        <li class="page-item {% if page_obj.number == num %}active{% endif %}">
+            <a class="page-link"
+               href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ num }}">
+                {{ num }}
+            </a>
+        </li>
+        {% endfor %}
+
+        <!-- Next -->
+        {% if page_obj.has_next %}
+        <li class="page-item">
+            <a class="page-link"
+               href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.next_page_number }}">
+                Next
+                <i class="bi bi-chevron-right"></i>
+            </a>
+        </li>
+        {% else %}
+        <li class="page-item disabled">
+            <span class="page-link">
+                Next
+                <i class="bi bi-chevron-right"></i>
+            </span>
+        </li>
+        {% endif %}
+
+    </ul>
+</nav>
+{% endif %}
 </div>
 
 <style>

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1428,9 +1428,12 @@ class TaskTestCase(TestCase):
     def _create_tasks_for_pagination(self, count=60):
         """Create enough tasks to trigger pagination."""
 
-        status = Status.objects.filter(team=self.team).first() \
-            if self.team else \
-            Status.objects.filter(
+        if self.team:
+            status = Status.objects.filter(
+                team=self.team
+            ).first()
+        else:
+            status = Status.objects.filter(
                 creator=self.user,
                 team__isnull=True
             ).first()
@@ -1443,9 +1446,9 @@ class TaskTestCase(TestCase):
                 team=self.team
             )
             task.executors.add(self.user)
-    
+
     def test_tasks_list_is_paginated(self):
-        """Check that pagination is enabled when task count exceeds page size."""
+        """Check that pagination is enabled for large task lists."""
 
         self._create_tasks_for_pagination(60)
         response = self.c.get(reverse('tasks:tasks-list'))
@@ -1454,7 +1457,7 @@ class TaskTestCase(TestCase):
 
     def test_tasks_list_max_50_tasks_per_page(self):
         """Check that no more than 50 tasks are displayed per page."""
-        
+
         self._create_tasks_for_pagination(60)
         response = self.c.get(reverse('tasks:tasks-list'))
         self.assertEqual(len(response.context['page_obj']), 50)
@@ -1481,7 +1484,6 @@ class TaskTestCase(TestCase):
             response,
             'sort=created_at&page=2'
         )
-
 
 
 class TaskFilterSaveEmptyTestCase(TestCase):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1425,6 +1425,64 @@ class TaskTestCase(TestCase):
         # Default view should show task-card class
         self.assertContains(response, 'task-card')
 
+    def _create_tasks_for_pagination(self, count=60):
+        """Create enough tasks to trigger pagination."""
+
+        status = Status.objects.filter(team=self.team).first() \
+            if self.team else \
+            Status.objects.filter(
+                creator=self.user,
+                team__isnull=True
+            ).first()
+
+        for i in range(count):
+            task = Task.objects.create(
+                name=f"Pagination Task {i}",
+                author=self.user,
+                status=status,
+                team=self.team
+            )
+            task.executors.add(self.user)
+    
+    def test_tasks_list_is_paginated(self):
+        """Check that pagination is enabled when task count exceeds page size."""
+
+        self._create_tasks_for_pagination(60)
+        response = self.c.get(reverse('tasks:tasks-list'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['is_paginated'])
+
+    def test_tasks_list_max_50_tasks_per_page(self):
+        """Check that no more than 50 tasks are displayed per page."""
+        
+        self._create_tasks_for_pagination(60)
+        response = self.c.get(reverse('tasks:tasks-list'))
+        self.assertEqual(len(response.context['page_obj']), 50)
+
+    def test_tasks_list_second_page_works(self):
+        """Check that the second page of tasks is accessible."""
+        self._create_tasks_for_pagination(60)
+
+        response = self.c.get(
+            reverse('tasks:tasks-list') + '?page=2'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['page_obj'].number, 2)
+
+    def test_pagination_preserves_sort_parameter(self):
+        """Check that sort parameters are preserved in pagination links."""
+
+        self._create_tasks_for_pagination(60)
+        response = self.c.get(
+            reverse('tasks:tasks-list') + '?sort=created_at'
+        )
+        self.assertContains(
+            response,
+            'sort=created_at&page=2'
+        )
+
+
 
 class TaskFilterSaveEmptyTestCase(TestCase):
     """Test cases for empty filter saving scenarios"""


### PR DESCRIPTION
## Description

Adds pagination to the task list to improve performance when a large number of tasks exist.

### Changes

* Added pagination to `TaskFilterView`
* Limited task list to 50 tasks per page
* Added Bootstrap 5 pagination controls
* Preserved filter and sort query parameters when navigating between pages
* Added tests for pagination functionality


## Developer Checklist

* [x] My code passes local tests (`manage.py test`)
* [x] My code passes the linter (`make lint`)
* [x] I have added new tests for my feature/bugfix
* [ ] I have updated `README.md` (if necessary)
* [x] I did NOT change the project version number
